### PR TITLE
Don't write newline character to cgroup node

### DIFF
--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -252,7 +252,7 @@
     <string name="spoofed_update_warning_message">To update to the new version, please first uninstall the current spoofed version, then download and install the new version.</string>
     <string name="spoofed_update_uninstall_button">Uninstall Current Version</string>
     <string name="spoofed_update_download_button">Download New Version</string>
-</resources>
+    
     <string name="app_dpi_title">DPI Scale</string>
     <string name="app_dpi_summary">Adjust the display density (DPI) of the app interface</string>
     <string name="dpi_current">Current DPI: %d</string>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -252,7 +252,7 @@
     <string name="spoofed_update_warning_message">To update to the new version, please first uninstall the current spoofed version, then download and install the new version.</string>
     <string name="spoofed_update_uninstall_button">Uninstall Current Version</string>
     <string name="spoofed_update_download_button">Download New Version</string>
-    
+</resources
     <string name="app_dpi_title">DPI Scale</string>
     <string name="app_dpi_summary">Adjust the display density (DPI) of the app interface</string>
     <string name="dpi_current">Current DPI: %d</string>

--- a/userspace/ksud_magic/src/utils.rs
+++ b/userspace/ksud_magic/src/utils.rs
@@ -145,7 +145,7 @@ fn switch_cgroup(grp: &str, pid: u32) {
 
     let fp = OpenOptions::new().append(true).open(path);
     if let std::result::Result::Ok(mut fp) = fp {
-        let _ = writeln!(fp, "{pid}");
+        let _ = write!(fp, "{pid}");
     }
 }
 

--- a/userspace/ksud_overlayfs/src/utils.rs
+++ b/userspace/ksud_overlayfs/src/utils.rs
@@ -151,7 +151,7 @@ fn switch_cgroup(grp: &str, pid: u32) {
 
     let fp = OpenOptions::new().append(true).open(path);
     if let std::result::Result::Ok(mut fp) = fp {
-        let _ = writeln!(fp, "{pid}");
+        let _ = write!(fp, "{pid}");
     }
 }
 


### PR DESCRIPTION
Don't write newline character to cgroup node Synced from KernelSU commit
https://github.com/tiann/KernelSU/commit/1364710021ee7fa25785526d1ef335f3a4d6ddc0
This prevents su hang on oplus devices, maybe related to bad kernel
hooks.