### PR TITLE
refactor(Kconfig): simplify KSU dependency logic

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -3,7 +3,7 @@ menu "KernelSU"
 config KSU
     tristate "KernelSU function support"
     default y
-    depends on KSU_SUSFS || KPROBES
+    select KPROBES if !KSU_SUSFS
     help
       Enable kernel-level root privileges on Android System.
       Requires CONFIG_KPROBES for kernel hooking support.


### PR DESCRIPTION
Use select instead of depends on for KPROBES when KSU_SUSFS is not enabled to make the configuration more straightforward